### PR TITLE
feat(collector): implement SoloPulse GitHub activity collector

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,4 +5,4 @@ jobs:
   placeholder:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "Future: run DocFX, output to wwwroot/docs/"
+      - run: echo "Future- run DocFX, output to wwwroot/docs/"

--- a/.github/workflows/pulse-weekly.yml
+++ b/.github/workflows/pulse-weekly.yml
@@ -1,10 +1,53 @@
-name: Weekly pulse
+name: Weekly Pulse
+
 on:
   schedule:
-    - cron: '0 23 * * 0'
+    - cron: "0 23 * * 0"
   workflow_dispatch:
+    inputs:
+      reason:
+        description: "Reason for manual run"
+        required: false
+        default: "manual test"
+
+permissions:
+  contents: write
+
 jobs:
-  placeholder:
+  collect:
     runs-on: ubuntu-latest
+
     steps:
-      - run: echo "Future: run Collector → metrics.json, then Narrator → weekly-friendly.md"
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+          include-prerelease: true
+
+      - name: Run Collector
+        run: dotnet run --project tools/SoloPulse.Collector --configuration Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_USER: ulfbou
+
+      - name: Verify generated output
+        run: |
+          ls -lh src/Ulfbou.Site/wwwroot/data/
+          jq '.schemaVersion' src/Ulfbou.Site/wwwroot/data/repos.json
+          jq '.repos | length' src/Ulfbou.Site/wwwroot/data/repos.json
+          jq '.schemaVersion' src/Ulfbou.Site/wwwroot/data/graph.json
+          jq '.nodes | length' src/Ulfbou.Site/wwwroot/data/graph.json
+          jq '.edges | length' src/Ulfbou.Site/wwwroot/data/graph.json
+
+      - name: Commit generated pulse data
+        run: |
+          git config user.name "pulse-bot"
+          git config user.email "pulse-bot@users.noreply.github.com"
+          git add src/Ulfbou.Site/wwwroot/data/
+          git diff --staged --quiet || git commit -m "chore: update pulse data [skip ci]"
+          git push

--- a/src/Ulfbou.Site/wwwroot/data/graph.json
+++ b/src/Ulfbou.Site/wwwroot/data/graph.json
@@ -1,1 +1,95 @@
-{ "schemaVersion": "1", "nodes": [ { "id": "dx.metadata", "label": "dx.metadata", "group": "core" }, { "id": "dx.domain", "label": "dx.domain", "group": "core" }, { "id": "dx.annotations", "label": "dx.annotations", "group": "support" }, { "id": "dx.facts", "label": "dx.facts", "group": "support" } ], "edges": [ { "source": "dx.metadata", "target": "dx.domain", "type": "depends" }, { "source": "dx.metadata", "target": "dx.annotations", "type": "depends" }, { "source": "dx.facts", "target": "dx.domain", "type": "depends" } ] }
+{
+  "schemaVersion": "1",
+  "generatedAt": "2026-05-27T11:05:49.0747615Z",
+  "nodes": [
+    {
+      "id": "dx.cli",
+      "label": "dx.cli",
+      "group": "core"
+    },
+    {
+      "id": "ulfbou.github.io",
+      "label": "ulfbou.github.io",
+      "group": "core"
+    },
+    {
+      "id": "portfolio",
+      "label": "portfolio",
+      "group": "core"
+    },
+    {
+      "id": "ai-playground",
+      "label": "ai-playground",
+      "group": "core"
+    },
+    {
+      "id": "quizbattle",
+      "label": "quizbattle",
+      "group": "core"
+    },
+    {
+      "id": "dxs",
+      "label": "dxs",
+      "group": "core"
+    },
+    {
+      "id": "gex.cli",
+      "label": "gex.cli",
+      "group": "core"
+    },
+    {
+      "id": "homebrew-tap",
+      "label": "homebrew-tap",
+      "group": "core"
+    },
+    {
+      "id": "syss8.opf.clean",
+      "label": "syss8.opf.clean",
+      "group": "core"
+    },
+    {
+      "id": "dx.scripts",
+      "label": "dx.scripts",
+      "group": "core"
+    },
+    {
+      "id": "atlasdeck",
+      "label": "atlasdeck",
+      "group": "core"
+    },
+    {
+      "id": "dx.domain",
+      "label": "dx.domain",
+      "group": "core"
+    },
+    {
+      "id": "zentientframework",
+      "label": "zentientframework",
+      "group": "core"
+    },
+    {
+      "id": "zentient.abstractions.core",
+      "label": "zentient.abstractions.core",
+      "group": "core"
+    },
+    {
+      "id": "zentient.testing",
+      "label": "zentient.testing",
+      "group": "core"
+    }
+  ],
+  "edges": [
+    {
+      "source": "dx.cli",
+      "target": "homebrew-tap",
+      "type": "temporal",
+      "weight": 0.4
+    },
+    {
+      "source": "homebrew-tap",
+      "target": "dx.cli",
+      "type": "temporal",
+      "weight": 0.4
+    }
+  ]
+}

--- a/src/Ulfbou.Site/wwwroot/data/repos.json
+++ b/src/Ulfbou.Site/wwwroot/data/repos.json
@@ -1,6 +1,186 @@
-[
-  { "name": "dx.metadata", "displayName": "Dx.Metadata", "status": "active", "summary": "Metadata model and source generation for domain-driven design", "githubUrl": "https://github.com/ulfbou/dx.metadata", "docsUrl": "/docs/dx.metadata/", "activityScore": 82 },
-  { "name": "dx.domain", "displayName": "Dx.Domain", "status": "needs-attention", "summary": "Core domain primitives and patterns", "githubUrl": "https://github.com/ulfbou/dx.domain", "docsUrl": "/docs/dx.domain/", "activityScore": 41 },
-  { "name": "dx.annotations", "displayName": "Dx.Annotations", "status": "quiet", "summary": "Attributes for modeling intent", "githubUrl": "https://github.com/ulfbou/dx.annotations", "docsUrl": "/docs/dx.annotations/", "activityScore": 18 },
-  { "name": "dx.facts", "displayName": "Dx.Facts", "status": "quiet", "summary": "Testing helpers for domain models", "githubUrl": "https://github.com/ulfbou/dx.facts", "docsUrl": null, "activityScore": 12 }
-]
+{
+  "schemaVersion": "1",
+  "generatedAt": "2026-05-27T11:05:49.0747615Z",
+  "repos": [
+    {
+      "name": "dx.cli",
+      "displayName": "Dx.Cli",
+      "language": "C#",
+      "momentum": 100,
+      "focusMinutes7d": 349,
+      "contextSwitchesOut": 1,
+      "lastDeepWork": "2026-05-25T18:20:41.0000000Z",
+      "returnRate": 0.93,
+      "openLoops": 1,
+      "summary": ""
+    },
+    {
+      "name": "ulfbou.github.io",
+      "displayName": "Ulfbou.Github.Io",
+      "language": "HTML",
+      "momentum": 12,
+      "focusMinutes7d": 0,
+      "contextSwitchesOut": 0,
+      "lastDeepWork": "2026-05-27T09:28:39.0000000Z",
+      "returnRate": 1,
+      "openLoops": 1,
+      "summary": ""
+    },
+    {
+      "name": "portfolio",
+      "displayName": "Portfolio",
+      "language": "C#",
+      "momentum": 6,
+      "focusMinutes7d": 0,
+      "contextSwitchesOut": 0,
+      "lastDeepWork": "2026-04-27T17:43:22.0000000Z",
+      "returnRate": 1,
+      "openLoops": 0,
+      "summary": ""
+    },
+    {
+      "name": "ai-playground",
+      "displayName": "Ai-playground",
+      "language": "unknown",
+      "momentum": 1,
+      "focusMinutes7d": 0,
+      "contextSwitchesOut": 0,
+      "lastDeepWork": "2026-05-01T06:25:34.0000000Z",
+      "returnRate": 1,
+      "openLoops": 0,
+      "summary": ""
+    },
+    {
+      "name": "quizbattle",
+      "displayName": "QuizBattle",
+      "language": "C#",
+      "momentum": 0,
+      "focusMinutes7d": 0,
+      "contextSwitchesOut": 0,
+      "lastDeepWork": "2026-01-22T09:49:35.0000000Z",
+      "returnRate": 0.75,
+      "openLoops": 15,
+      "summary": ""
+    },
+    {
+      "name": "dxs",
+      "displayName": "Dxs",
+      "language": "C#",
+      "momentum": 0,
+      "focusMinutes7d": 0,
+      "contextSwitchesOut": 0,
+      "lastDeepWork": "2026-04-18T10:51:58.0000000Z",
+      "returnRate": 0.5,
+      "openLoops": 5,
+      "summary": ""
+    },
+    {
+      "name": "gex.cli",
+      "displayName": "Gex.Cli",
+      "language": "C#",
+      "momentum": 0,
+      "focusMinutes7d": 0,
+      "contextSwitchesOut": 0,
+      "lastDeepWork": "2025-12-10T07:46:10.0000000Z",
+      "returnRate": 1,
+      "openLoops": 3,
+      "summary": ""
+    },
+    {
+      "name": "homebrew-tap",
+      "displayName": "Homebrew-tap",
+      "language": "Ruby",
+      "momentum": 0,
+      "focusMinutes7d": 0,
+      "contextSwitchesOut": 1,
+      "lastDeepWork": "2026-04-08T18:51:45.0000000Z",
+      "returnRate": 0.67,
+      "openLoops": 0,
+      "summary": ""
+    },
+    {
+      "name": "syss8.opf.clean",
+      "displayName": "SYSS8.OPF.Clean",
+      "language": "C#",
+      "momentum": 0,
+      "focusMinutes7d": 0,
+      "contextSwitchesOut": 0,
+      "lastDeepWork": "2026-03-05T10:56:09.0000000Z",
+      "returnRate": 0.88,
+      "openLoops": 0,
+      "summary": ""
+    },
+    {
+      "name": "dx.scripts",
+      "displayName": "Dx.Scripts",
+      "language": "Shell",
+      "momentum": 0,
+      "focusMinutes7d": 0,
+      "contextSwitchesOut": 0,
+      "lastDeepWork": "2026-02-20T12:13:25.0000000Z",
+      "returnRate": 1,
+      "openLoops": 0,
+      "summary": ""
+    },
+    {
+      "name": "atlasdeck",
+      "displayName": "AtlasDeck",
+      "language": "unknown",
+      "momentum": 0,
+      "focusMinutes7d": 0,
+      "contextSwitchesOut": 0,
+      "lastDeepWork": "2026-01-21T20:23:15.0000000Z",
+      "returnRate": 1,
+      "openLoops": 0,
+      "summary": ""
+    },
+    {
+      "name": "dx.domain",
+      "displayName": "Dx.Domain",
+      "language": "C#",
+      "momentum": 0,
+      "focusMinutes7d": 0,
+      "contextSwitchesOut": 0,
+      "lastDeepWork": "2025-12-13T07:39:01.0000000Z",
+      "returnRate": 1,
+      "openLoops": 0,
+      "summary": ""
+    },
+    {
+      "name": "zentientframework",
+      "displayName": "ZentientFramework",
+      "language": "C#",
+      "momentum": 0,
+      "focusMinutes7d": 0,
+      "contextSwitchesOut": 18,
+      "lastDeepWork": "2025-11-26T07:01:15.0000000Z",
+      "returnRate": 0.83,
+      "openLoops": 0,
+      "summary": ""
+    },
+    {
+      "name": "zentient.abstractions.core",
+      "displayName": "Zentient.Abstractions.Core",
+      "language": "C#",
+      "momentum": 0,
+      "focusMinutes7d": 0,
+      "contextSwitchesOut": 0,
+      "lastDeepWork": "2025-10-08T12:39:31.0000000Z",
+      "returnRate": 0.5,
+      "openLoops": 0,
+      "summary": ""
+    },
+    {
+      "name": "zentient.testing",
+      "displayName": "Zentient.Testing",
+      "language": "C#",
+      "momentum": 0,
+      "focusMinutes7d": 0,
+      "contextSwitchesOut": 0,
+      "lastDeepWork": "2025-09-19T11:39:04.0000000Z",
+      "returnRate": 1,
+      "openLoops": 0,
+      "summary": ""
+    }
+  ]
+}

--- a/src/Ulfbou.Site/wwwroot/data/rhythm.json
+++ b/src/Ulfbou.Site/wwwroot/data/rhythm.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": "1",
+  "generatedAt": "2026-05-27T11:05:49.0747615Z",
+  "peakHours": [
+    8,
+    12,
+    14
+  ],
+  "avgSessionMinutes": 43,
+  "fragmentationIndex": 1,
+  "deepWorkStreakDays": 1,
+  "lastQuietPeriod": "2026-05-26"
+}

--- a/tools/SoloPulse.Collector/GitHubClient.cs
+++ b/tools/SoloPulse.Collector/GitHubClient.cs
@@ -1,0 +1,194 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+namespace SoloPulse.Collector;
+
+/// <summary>
+/// Thin wrapper around the GitHub GraphQL API (https://api.github.com/graphql).
+/// Uses a single batched query for repo+commit+PR data, then up to 5 additional
+/// requests to fetch .csproj content for dependency-edge resolution.
+/// </summary>
+sealed class GitHubGraphQlClient : IDisposable
+{
+    private readonly HttpClient _http;
+
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    // Main query: repos + last-100 commits + open PRs + open issues + root tree
+    // Filters: isFork=false, privacy=PUBLIC — archived repos are filtered client-side.
+    private const string ReposQuery = """
+        query($login: String!, $repoCount: Int!) {
+          user(login: $login) {
+            repositories(
+              first: $repoCount
+              isFork: false
+              privacy: PUBLIC
+              orderBy: { field: PUSHED_AT, direction: DESC }
+            ) {
+              nodes {
+                name
+                description
+                isArchived
+                primaryLanguage { name }
+                pushedAt
+                object(expression: "HEAD:") {
+                  ... on Tree {
+                    entries { name type }
+                  }
+                }
+                defaultBranchRef {
+                  target {
+                    ... on Commit {
+                      history(first: 100) {
+                        nodes { committedDate message }
+                      }
+                    }
+                  }
+                }
+                pullRequests(
+                  first: 20
+                  states: [OPEN]
+                  orderBy: { field: CREATED_AT, direction: DESC }
+                ) {
+                  nodes { createdAt state }
+                }
+                issues(
+                  first: 20
+                  states: [OPEN]
+                  orderBy: { field: CREATED_AT, direction: DESC }
+                ) {
+                  nodes { createdAt state }
+                }
+              }
+            }
+          }
+        }
+        """;
+
+    // Secondary query: fetch a single file's text content from a repo.
+    private const string FileContentQuery = """
+        query($owner: String!, $name: String!, $expr: String!) {
+          repository(owner: $owner, name: $name) {
+            object(expression: $expr) {
+              ... on Blob { text }
+            }
+          }
+        }
+        """;
+
+    public GitHubGraphQlClient(string token)
+    {
+        _http = new HttpClient { BaseAddress = new Uri("https://api.github.com") };
+        _http.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", token);
+        _http.DefaultRequestHeaders.UserAgent.ParseAdd("SoloPulse.Collector/1.0");
+        _http.DefaultRequestHeaders.Accept.ParseAdd("application/vnd.github.v4+json");
+        _http.Timeout = TimeSpan.FromSeconds(30);
+    }
+
+    /// <summary>
+    /// Returns all public non-fork repositories for <paramref name="login"/>.
+    /// Archived repos returned by the API are filtered out client-side.
+    /// </summary>
+    public async Task<List<RepositoryNode>> FetchReposAsync(
+        string login, CancellationToken ct = default)
+    {
+        var data = await ExecuteWithRetryAsync<UserQueryData>(
+            ReposQuery,
+            new { login, repoCount = 30 },
+            ct);
+
+        return (data?.User?.Repositories?.Nodes ?? [])
+            .Where(r => !r.IsArchived)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Fetches the text content of a single file from a repository.
+    /// Returns <c>null</c> when the file does not exist or could not be read.
+    /// </summary>
+    public async Task<string?> FetchFileContentAsync(
+        string owner, string repo, string path, CancellationToken ct = default)
+    {
+        var data = await ExecuteWithRetryAsync<FileQueryData>(
+            FileContentQuery,
+            new { owner, name = repo, expr = $"HEAD:{path}" },
+            ct);
+
+        return data?.Repository?.Object?.Text;
+    }
+
+    // ─── Infrastructure ───────────────────────────────────────────────────────
+
+    private async Task<T?> ExecuteWithRetryAsync<T>(
+        string query, object variables, CancellationToken ct)
+        where T : class
+    {
+        for (int attempt = 0; attempt < 2; attempt++)
+        {
+            try
+            {
+                var payload = JsonSerializer.Serialize(
+                    new { query, variables }, JsonOpts);
+
+                using var response = await _http.PostAsync(
+                    "/graphql",
+                    new StringContent(payload, Encoding.UTF8, "application/json"),
+                    ct);
+
+                if (response.StatusCode is HttpStatusCode.Forbidden
+                                        or HttpStatusCode.TooManyRequests)
+                {
+                    if (attempt == 0)
+                    {
+                        // Honour Retry-After when present; default 60 s.
+                        int waitSeconds = 60;
+                        if (response.Headers.TryGetValues("Retry-After", out var values)
+                            && int.TryParse(values.FirstOrDefault(), out int ra))
+                            waitSeconds = ra;
+
+                        Console.Error.WriteLine(
+                            $"Rate limited — waiting {waitSeconds}s before retry…");
+                        await Task.Delay(TimeSpan.FromSeconds(waitSeconds), ct);
+                        continue;
+                    }
+
+                    Console.Error.WriteLine(
+                        "Rate limit persists after retry — returning empty data.");
+                    return default;
+                }
+
+                response.EnsureSuccessStatusCode();
+
+                var json = await response.Content.ReadAsStringAsync(ct);
+                var result = JsonSerializer.Deserialize<GraphQlResponse<T>>(json, JsonOpts);
+
+                if (result?.Errors is { Count: > 0 })
+                    foreach (var err in result.Errors)
+                        Console.Error.WriteLine($"GraphQL error: {err.Message}");
+
+                return result?.Data;
+            }
+            catch (HttpRequestException ex) when (attempt == 0)
+            {
+                Console.Error.WriteLine($"Network error: {ex.Message} — retrying once…");
+                await Task.Delay(TimeSpan.FromSeconds(5), ct);
+            }
+            catch (HttpRequestException ex)
+            {
+                Console.Error.WriteLine($"Network error: {ex.Message} — returning empty data.");
+                return default;
+            }
+        }
+
+        return default;
+    }
+
+    public void Dispose() => _http.Dispose();
+}

--- a/tools/SoloPulse.Collector/MetricsCalculator.cs
+++ b/tools/SoloPulse.Collector/MetricsCalculator.cs
@@ -1,0 +1,325 @@
+using System.Xml.Linq;
+
+namespace SoloPulse.Collector;
+
+/// <summary>
+/// Pure, stateless calculation functions for all SoloPulse metrics.
+/// No I/O, no side effects — all methods are safe to unit-test in isolation.
+/// </summary>
+static class MetricsCalculator
+{
+    // ─── Tuning constants ─────────────────────────────────────────────────────
+
+    /// <summary>Gap between commits that ends a focus session.</summary>
+    private static readonly TimeSpan SessionGap = TimeSpan.FromMinutes(90);
+
+    /// <summary>Window in which a repo switch counts as a context switch.</summary>
+    private static readonly TimeSpan ContextSwitchWindow = TimeSpan.FromHours(2);
+
+    /// <summary>Minimum gap between commits before treating it as a departure from a repo.</summary>
+    private static readonly TimeSpan ReturnGap = TimeSpan.FromHours(24);
+
+    /// <summary>Window in which cross-repo commits produce a temporal edge.</summary>
+    private static readonly TimeSpan TemporalEdgeWindow = TimeSpan.FromHours(2);
+
+    // ─── Momentum ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Calculates raw (un-normalised) momentum per repo using the formula:
+    ///   score = commits_last_7d × 1.0 + commits_8–14d × 0.5 + commits_15–30d × 0.2
+    /// Then normalises all repos to 0–100.
+    /// </summary>
+    public static Dictionary<string, int> CalculateMomentum(
+        Dictionary<string, List<DateTime>> commitsByRepo)
+    {
+        var now = DateTime.UtcNow;
+        var raw = new Dictionary<string, double>();
+
+        foreach (var (repo, dates) in commitsByRepo)
+        {
+            double score = 0;
+            foreach (var d in dates)
+            {
+                double ageDays = (now - d).TotalDays;
+                score += ageDays <= 7   ? 1.0 :
+                         ageDays <= 14  ? 0.5 :
+                         ageDays <= 30  ? 0.2 : 0;
+            }
+            raw[repo] = score;
+        }
+
+        double max = raw.Values.DefaultIfEmpty(0).Max();
+
+        return raw.ToDictionary(
+            kv => kv.Key,
+            kv => max > 0 ? (int)Math.Round(kv.Value / max * 100) : 0);
+    }
+
+    // ─── Focus minutes ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Groups commits within the last 7 days into sessions (gap &lt; 90 min counts
+    /// as the same session) and returns the total of all session durations in minutes.
+    /// A session with a single commit contributes 0 minutes (no elapsed time).
+    /// </summary>
+    public static int CalculateFocusMinutes7d(List<DateTime> commits)
+    {
+        var now = DateTime.UtcNow;
+        var recent = commits
+            .Where(d => (now - d).TotalDays <= 7)
+            .OrderBy(d => d)
+            .ToList();
+
+        if (recent.Count == 0) return 0;
+
+        int totalMinutes = 0;
+        var sessionStart = recent[0];
+        var sessionEnd   = recent[0];
+
+        for (int i = 1; i < recent.Count; i++)
+        {
+            if (recent[i] - sessionEnd < SessionGap)
+            {
+                sessionEnd = recent[i];
+            }
+            else
+            {
+                totalMinutes += (int)(sessionEnd - sessionStart).TotalMinutes;
+                sessionStart = recent[i];
+                sessionEnd   = recent[i];
+            }
+        }
+        totalMinutes += (int)(sessionEnd - sessionStart).TotalMinutes;
+
+        return totalMinutes;
+    }
+
+    // ─── Context switches ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Counts the number of times each repo was abandoned for a different repo within
+    /// a 2-hour window.  Operates on the global commit timeline across all repos.
+    /// </summary>
+    public static Dictionary<string, int> CalculateContextSwitches(
+        List<RepoCommit> allCommits)
+    {
+        var sorted = allCommits.OrderBy(c => c.CommittedAt).ToList();
+
+        var switches = allCommits
+            .Select(c => c.RepoName)
+            .Distinct(StringComparer.Ordinal)
+            .ToDictionary(r => r, _ => 0, StringComparer.Ordinal);
+
+        for (int i = 0; i < sorted.Count - 1; i++)
+        {
+            var curr = sorted[i];
+            var next = sorted[i + 1];
+
+            if (!string.Equals(curr.RepoName, next.RepoName, StringComparison.Ordinal)
+                && next.CommittedAt - curr.CommittedAt < ContextSwitchWindow)
+            {
+                switches[curr.RepoName]++;
+            }
+        }
+
+        return switches;
+    }
+
+    // ─── Return rate ──────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Measures how reliably you return to a repo after leaving it.
+    /// Formula: interior_returns / (interior_returns + terminal_departure_flag).
+    /// Interior return = gap &gt; 24 h between two consecutive commits in this repo.
+    /// Terminal departure = last commit was &gt; 24 h ago (you have not returned yet).
+    /// Returns 1.0 when there are no gaps (steady engagement).
+    /// </summary>
+    public static double CalculateReturnRate(List<DateTime> commits)
+    {
+        if (commits.Count < 2) return 1.0;
+
+        var sorted = commits.OrderBy(d => d).ToList();
+        int interiorReturns = 0;
+
+        for (int i = 0; i < sorted.Count - 1; i++)
+            if (sorted[i + 1] - sorted[i] > ReturnGap)
+                interiorReturns++;
+
+        if (interiorReturns == 0) return 1.0;
+
+        bool terminalDeparture = DateTime.UtcNow - sorted[^1] > ReturnGap;
+        int totalDepartures = interiorReturns + (terminalDeparture ? 1 : 0);
+
+        return Math.Round((double)interiorReturns / totalDepartures, 2);
+    }
+
+    // ─── Graph edges ──────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Builds temporal edges: every time commits in repo A and repo B fall within
+    /// a 2-hour window, their edge weight increases by 0.1 (capped at 1.0).
+    /// </summary>
+    public static List<GraphEdge> BuildTemporalEdges(List<RepoCommit> allCommits)
+    {
+        var sorted = allCommits.OrderBy(c => c.CommittedAt).ToList();
+        var weights = new Dictionary<(string, string), double>();
+
+        for (int i = 0; i < sorted.Count; i++)
+        {
+            for (int j = i + 1; j < sorted.Count; j++)
+            {
+                var gap = sorted[j].CommittedAt - sorted[i].CommittedAt;
+                if (gap > TemporalEdgeWindow) break;
+
+                if (string.Equals(sorted[i].RepoName, sorted[j].RepoName,
+                        StringComparison.Ordinal))
+                    continue;
+
+                var key = (sorted[i].RepoName, sorted[j].RepoName);
+                weights[key] = Math.Min(1.0, weights.GetValueOrDefault(key) + 0.1);
+            }
+        }
+
+        return weights
+            .Select(kv => new GraphEdge(
+                kv.Key.Item1, kv.Key.Item2,
+                "temporal",
+                Math.Round(kv.Value, 1)))
+            .ToList();
+    }
+
+    /// <summary>
+    /// Parses ProjectReference elements from a .csproj XML string.
+    /// Returns repo names (lowercased file stem, without path or extension).
+    /// Invalid XML is silently ignored.
+    /// </summary>
+    public static List<string> ParseProjectReferences(string csprojContent)
+    {
+        var refs = new List<string>();
+        try
+        {
+            var doc = XDocument.Parse(csprojContent);
+            foreach (var pr in doc.Descendants("ProjectReference"))
+            {
+                var include = pr.Attribute("Include")?.Value;
+                if (string.IsNullOrWhiteSpace(include)) continue;
+                refs.Add(Path.GetFileNameWithoutExtension(include).ToLowerInvariant());
+            }
+        }
+        catch
+        {
+            // Malformed XML — skip silently.
+        }
+        return refs;
+    }
+
+    // ─── Rhythm ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Derives rhythm metrics from the complete commit timeline.
+    /// </summary>
+    /// <param name="allCommits">All commits across all repos.</param>
+    public static (
+        List<int> PeakHours,
+        int AvgSessionMinutes,
+        double FragmentationIndex,
+        int DeepWorkStreakDays,
+        string? LastQuietPeriod
+    ) CalculateRhythm(List<RepoCommit> allCommits)
+    {
+        if (allCommits.Count == 0)
+            return ([], 0, 0.0, 0, null);
+
+        var now = DateTime.UtcNow;
+        var recent7d  = allCommits.Where(c => (now - c.CommittedAt).TotalDays <= 7).ToList();
+        var recent30d = allCommits.Where(c => (now - c.CommittedAt).TotalDays <= 30).ToList();
+
+        // Peak commit hours (top 3) from all-time history.
+        var peakHours = allCommits
+            .GroupBy(c => c.CommittedAt.Hour)
+            .OrderByDescending(g => g.Count())
+            .Take(3)
+            .Select(g => g.Key)
+            .OrderBy(h => h)
+            .ToList();
+
+        // Average session minutes across all repos for the last 7 days.
+        int avgSessionMinutes = CalculateAvgSessionMinutes(
+            recent7d.Select(c => c.CommittedAt).ToList());
+
+        // Fragmentation: distinct repos touched per day, 7-day average.
+        double fragmentationIndex = 0;
+        if (recent7d.Count > 0)
+        {
+            var reposPerDay = recent7d
+                .GroupBy(c => c.CommittedAt.Date)
+                .Select(g => g.Select(c => c.RepoName).Distinct().Count())
+                .ToList();
+            fragmentationIndex = reposPerDay.Count > 0
+                ? Math.Round(reposPerDay.Average(), 1) : 0;
+        }
+
+        // Consecutive-day commit streak (most recent first).
+        var commitDays = recent30d
+            .Select(c => c.CommittedAt.Date)
+            .Distinct()
+            .OrderByDescending(d => d)
+            .ToList();
+
+        int streakDays = 0;
+        if (commitDays.Count > 0 && (now.Date - commitDays[0]).TotalDays <= 1)
+        {
+            streakDays = 1;
+            for (int i = 1; i < commitDays.Count; i++)
+            {
+                if ((commitDays[i - 1] - commitDays[i]).TotalDays == 1)
+                    streakDays++;
+                else
+                    break;
+            }
+        }
+
+        // Most recent quiet day (no commits) in the last 30 days.
+        var activeSet = commitDays.ToHashSet();
+        var lastQuietPeriod = Enumerable
+            .Range(0, 30)
+            .Select(i => now.Date.AddDays(-i))
+            .FirstOrDefault(d => !activeSet.Contains(d))
+            is DateTime quiet && quiet != default
+                ? quiet.ToString("yyyy-MM-dd")
+                : null;
+
+        return (peakHours, avgSessionMinutes, fragmentationIndex, streakDays, lastQuietPeriod);
+    }
+
+    // ─── Private helpers ──────────────────────────────────────────────────────
+
+    private static int CalculateAvgSessionMinutes(List<DateTime> timestamps)
+    {
+        var sorted = timestamps.OrderBy(d => d).ToList();
+        if (sorted.Count == 0) return 0;
+
+        int totalMinutes = 0;
+        int sessionCount = 1;
+        var sessionStart = sorted[0];
+        var sessionEnd   = sorted[0];
+
+        for (int i = 1; i < sorted.Count; i++)
+        {
+            if (sorted[i] - sessionEnd < SessionGap)
+            {
+                sessionEnd = sorted[i];
+            }
+            else
+            {
+                totalMinutes += (int)(sessionEnd - sessionStart).TotalMinutes;
+                sessionStart  = sorted[i];
+                sessionEnd    = sorted[i];
+                sessionCount++;
+            }
+        }
+        totalMinutes += (int)(sessionEnd - sessionStart).TotalMinutes;
+
+        return totalMinutes / sessionCount;
+    }
+}

--- a/tools/SoloPulse.Collector/Models.cs
+++ b/tools/SoloPulse.Collector/Models.cs
@@ -1,0 +1,123 @@
+using System.Text.Json.Serialization;
+
+namespace SoloPulse.Collector;
+
+// ─── Output: repos.json ──────────────────────────────────────────────────────
+
+/// <summary>Root document written to repos.json.</summary>
+record ReposFile(
+    string SchemaVersion,
+    string GeneratedAt,
+    List<RepoEntry> Repos);
+
+/// <summary>Per-repository solo-developer metrics.</summary>
+record RepoEntry(
+    string Name,
+    string DisplayName,
+    string Language,
+    /// <summary>0-100, weighted by recency (7d×1.0 + 8-14d×0.5 + 15-30d×0.2), normalised.</summary>
+    int Momentum,
+    /// <summary>Sum of commit-session durations in the last 7 days (sessions separated by ≥90 min gap).</summary>
+    int FocusMinutes7d,
+    /// <summary>Times you switched away to another repo within a 2-hour window.</summary>
+    int ContextSwitchesOut,
+    string? LastDeepWork,
+    /// <summary>Interior gaps ÷ (interior gaps + terminal departure); 1.0 when no departures.</summary>
+    double ReturnRate,
+    /// <summary>Open PRs + open issues (proxy for unresolved work).</summary>
+    int OpenLoops,
+    string Summary);
+
+// ─── Output: graph.json ───────────────────────────────────────────────────────
+
+/// <summary>Root document written to graph.json.</summary>
+record GraphFile(
+    string SchemaVersion,
+    string GeneratedAt,
+    List<GraphNode> Nodes,
+    List<GraphEdge> Edges);
+
+record GraphNode(string Id, string Label, string Group);
+
+/// <summary>
+/// Edge types:
+///   "dependency" — repo A has a ProjectReference to repo B in its .csproj.
+///   "temporal"   — commits to A and B occurred within 2 hours of each other.
+/// </summary>
+record GraphEdge(string Source, string Target, string Type, double Weight);
+
+// ─── Output: rhythm.json ──────────────────────────────────────────────────────
+
+/// <summary>Root document written to rhythm.json.</summary>
+record RhythmFile(
+    string SchemaVersion,
+    string GeneratedAt,
+    List<int> PeakHours,
+    int AvgSessionMinutes,
+    /// <summary>Average number of distinct repos touched per day over the last 7 days.</summary>
+    double FragmentationIndex,
+    int DeepWorkStreakDays,
+    string? LastQuietPeriod);
+
+// ─── GitHub GraphQL response models ──────────────────────────────────────────
+
+record GraphQlRequest(string Query, object Variables);
+
+record GraphQlResponse<T>(T? Data, List<GraphQlError>? Errors);
+
+record GraphQlError(string Message);
+
+// User + repositories query
+record UserQueryData(UserData? User);
+
+record UserData(RepositoryConnection? Repositories);
+
+record RepositoryConnection(List<RepositoryNode>? Nodes);
+
+record RepositoryNode(
+    string Name,
+    string? Description,
+    PrimaryLanguage? PrimaryLanguage,
+    string PushedAt,
+    bool IsArchived,
+    bool IsFork,
+    /// <summary>Root tree (expression "HEAD:"); mapped from the JSON key "object".</summary>
+    [property: JsonPropertyName("object")] TreeObject? Tree,
+    DefaultBranchRefData? DefaultBranchRef,
+    PullRequestConnection? PullRequests,
+    IssueConnection? Issues);
+
+record PrimaryLanguage(string Name);
+
+record TreeObject(List<TreeEntry>? Entries);
+
+record TreeEntry(string Name, string Type);
+
+record DefaultBranchRefData(CommitTarget? Target);
+
+record CommitTarget(CommitHistory? History);
+
+record CommitHistory(List<CommitNode>? Nodes);
+
+record CommitNode(string CommittedDate, string Message);
+
+record PullRequestConnection(List<PullRequestNode>? Nodes);
+
+record PullRequestNode(string CreatedAt, string? MergedAt, string? ClosedAt, string State);
+
+record IssueConnection(List<IssueNode>? Nodes);
+
+record IssueNode(string CreatedAt, string? ClosedAt, string State);
+
+// File-content query (for .csproj dependency parsing)
+record FileQueryData(RepositoryBlob? Repository);
+
+record RepositoryBlob(
+    [property: JsonPropertyName("object")] BlobContent? Object);
+
+record BlobContent(string? Text);
+
+// ─── Internal processing model ────────────────────────────────────────────────
+
+/// <summary>Flattened commit used across all metric calculations.</summary>
+record RepoCommit(string RepoName, DateTime CommittedAt, string Message);

--- a/tools/SoloPulse.Collector/Program.cs
+++ b/tools/SoloPulse.Collector/Program.cs
@@ -1,0 +1,259 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using SoloPulse.Collector;
+
+// ─── Configuration ────────────────────────────────────────────────────────────
+
+const int MaxPublicRepos = 15;
+const int MaxPublicGraphEdges = 30;
+
+var token = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
+if (string.IsNullOrWhiteSpace(token))
+{
+    Console.Error.WriteLine("GITHUB_TOKEN required");
+    return 1;
+}
+
+var targetUser = Environment.GetEnvironmentVariable("TARGET_USER") ?? "ulfbou";
+var outputDir  = Environment.GetEnvironmentVariable("OUTPUT_DIR") ?? FindOutputDir();
+
+Directory.CreateDirectory(outputDir);
+
+var jsonOptions = new JsonSerializerOptions
+{
+    PropertyNamingPolicy        = JsonNamingPolicy.CamelCase,
+    WriteIndented               = true,
+    DefaultIgnoreCondition      = JsonIgnoreCondition.WhenWritingNull,
+    NumberHandling              = JsonNumberHandling.Strict,
+};
+
+var generatedAt = DateTime.UtcNow.ToString("o");
+using var cts   = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+
+// ─── Fetch ────────────────────────────────────────────────────────────────────
+
+List<RepositoryNode> repos = [];
+
+try
+{
+    using var client = new GitHubGraphQlClient(token);
+    repos = await client.FetchReposAsync(targetUser, cts.Token);
+
+    // Dependency edges: parse .csproj from top 5 repos by pushedAt.
+    var depEdges = new List<GraphEdge>();
+
+    foreach (var repo in repos.Take(5))
+    {
+        var csprojName = repo.Tree?.Entries?
+            .FirstOrDefault(e => e.Name.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
+            ?.Name;
+
+        if (csprojName is null) continue;
+
+        var content = await client.FetchFileContentAsync(
+            targetUser, repo.Name, csprojName, cts.Token);
+
+        if (content is null) continue;
+
+        var targets = MetricsCalculator.ParseProjectReferences(content);
+        var repoNames = repos
+            .Select(r => NormalizeRepoId(r.Name))
+            .ToHashSet(StringComparer.Ordinal);
+
+        foreach (var target in targets)
+        {
+            var sourceId = NormalizeRepoId(repo.Name);
+            var targetId = NormalizeRepoId(target);
+
+            // Only emit edges to repos we actually fetched.
+            if (repoNames.Contains(targetId)
+                && !targetId.Equals(sourceId, StringComparison.Ordinal))
+            {
+                depEdges.Add(new GraphEdge(
+                    sourceId,
+                    targetId,
+                    "dependency",
+                    0.8));
+            }
+        }
+    }
+
+    // ─── Build metrics inputs ─────────────────────────────────────────────────
+
+    var allCommits = repos
+        .SelectMany(r => r.DefaultBranchRef?.Target?.History?.Nodes?
+            .Select(c => new RepoCommit(
+                r.Name,
+                DateTime.Parse(c.CommittedDate, null,
+                    System.Globalization.DateTimeStyles.RoundtripKind),
+                c.Message))
+            ?? [])
+        .ToList();
+
+    var commitsByRepo = allCommits
+        .GroupBy(c => c.RepoName, StringComparer.Ordinal)
+        .ToDictionary(g => g.Key, g => g.Select(c => c.CommittedAt).ToList());
+
+    var momentum         = MetricsCalculator.CalculateMomentum(commitsByRepo);
+    var contextSwitches  = MetricsCalculator.CalculateContextSwitches(allCommits);
+    var temporalEdges    = MetricsCalculator.BuildTemporalEdges(allCommits);
+
+    var (peakHours, avgSessionMinutes, fragmentationIndex, streakDays, lastQuietPeriod)
+        = MetricsCalculator.CalculateRhythm(allCommits);
+
+    // ─── Build output ─────────────────────────────────────────────────────────
+
+    int medianMomentum = repos.Count > 0
+        ? momentum.Values.OrderBy(v => v).ElementAt(momentum.Count / 2)
+        : 0;
+
+    var repoEntries = repos.Select(r =>
+    {
+        var commits  = commitsByRepo.GetValueOrDefault(r.Name) ?? [];
+        int mom      = momentum.GetValueOrDefault(r.Name);
+        int openPRs  = r.PullRequests?.Nodes?.Count(p => p.State == "OPEN") ?? 0;
+        int openIss  = r.Issues?.Nodes?.Count(i => i.State == "OPEN") ?? 0;
+
+        // Last commit timestamp = latest deep-work timestamp
+        var lastCommit = commits.Count > 0
+            ? (DateTime?)commits.Max()
+            : null;
+
+        return new RepoEntry(
+            Name:               NormalizeRepoId(r.Name),
+            DisplayName:        ToDisplayName(r.Name),
+            Language:           r.PrimaryLanguage?.Name ?? "unknown",
+            Momentum:           mom,
+            FocusMinutes7d:     MetricsCalculator.CalculateFocusMinutes7d(commits),
+            ContextSwitchesOut: contextSwitches.GetValueOrDefault(r.Name),
+            LastDeepWork:       lastCommit?.ToString("o"),
+            ReturnRate:         MetricsCalculator.CalculateReturnRate(commits),
+            OpenLoops:          openPRs + openIss,
+            Summary:            r.Description ?? string.Empty);
+    }).ToList();
+
+    var publicRepos = repoEntries
+        .GroupBy(r => NormalizeRepoId(r.Name))
+        .Select(g => g
+            .OrderByDescending(r => r.Momentum)
+            .ThenByDescending(r => r.FocusMinutes7d)
+            .ThenByDescending(r => r.OpenLoops)
+            .ThenByDescending(r => r.LastDeepWork ?? string.Empty)
+            .First())
+        .OrderByDescending(r => r.Momentum)
+        .ThenByDescending(r => r.FocusMinutes7d)
+        .ThenByDescending(r => r.OpenLoops)
+        .ThenByDescending(r => r.LastDeepWork ?? string.Empty)
+        .Take(MaxPublicRepos)
+        .ToList();
+
+    var publicRepoIds = publicRepos
+        .Select(r => NormalizeRepoId(r.Name))
+        .ToHashSet(StringComparer.Ordinal);
+
+    var publicNodes = publicRepos.Select(r => new GraphNode(
+        Id:    NormalizeRepoId(r.Name),
+        Label: r.Name,
+        Group: r.Momentum >= medianMomentum ? "core" : "support"))
+        .ToList();
+
+    var publicEdges = depEdges
+        .Concat(temporalEdges)
+        .Select(e => new GraphEdge(
+            NormalizeRepoId(e.Source),
+            NormalizeRepoId(e.Target),
+            e.Type,
+            e.Weight))
+        .Where(e => publicRepoIds.Contains(e.Source))
+        .Where(e => publicRepoIds.Contains(e.Target))
+        .Where(e => e.Source != e.Target)
+        .GroupBy(e => new { e.Source, e.Target, e.Type })
+        .Select(g => g
+            .OrderByDescending(e => e.Weight)
+            .First())
+        .OrderByDescending(e => e.Weight)
+        .Take(MaxPublicGraphEdges)
+        .ToList();
+
+    // ─── Write files ──────────────────────────────────────────────────────────
+
+    var reposFile = new ReposFile("1", generatedAt, publicRepos);
+    var graphFile = new GraphFile("1", generatedAt, publicNodes, publicEdges);
+    var rhythmFile = new RhythmFile(
+        SchemaVersion:      "1",
+        GeneratedAt:        generatedAt,
+        PeakHours:          peakHours,
+        AvgSessionMinutes:  avgSessionMinutes,
+        FragmentationIndex: fragmentationIndex,
+        DeepWorkStreakDays: streakDays,
+        LastQuietPeriod:    lastQuietPeriod);
+
+    await WriteJsonAsync(Path.Combine(outputDir, "repos.json"),  reposFile,  jsonOptions);
+    await WriteJsonAsync(Path.Combine(outputDir, "graph.json"),  graphFile,  jsonOptions);
+    await WriteJsonAsync(Path.Combine(outputDir, "rhythm.json"), rhythmFile, jsonOptions);
+
+    int totalFocusMinutes = publicRepos.Sum(r => r.FocusMinutes7d);
+    Console.WriteLine(
+        $"Collected {publicRepos.Count} public repos, {publicEdges.Count} public edges, " +
+        $"{totalFocusMinutes} minutes focus, written to \"{outputDir}\"");
+
+    return 0;
+}
+catch (Exception ex)
+{
+    Console.Error.WriteLine($"Fatal error: {ex.Message}");
+
+    // Write valid but empty output so the Blazor site does not get a 404.
+    var empty = new ReposFile("1", generatedAt, []);
+    var emptyGraph = new GraphFile("1", generatedAt, [], []);
+    var emptyRhythm = new RhythmFile("1", generatedAt, [], 0, 0.0, 0, null);
+
+    await WriteJsonAsync(Path.Combine(outputDir, "repos.json"),  empty,        jsonOptions);
+    await WriteJsonAsync(Path.Combine(outputDir, "graph.json"),  emptyGraph,   jsonOptions);
+    await WriteJsonAsync(Path.Combine(outputDir, "rhythm.json"), emptyRhythm,  jsonOptions);
+
+    return 0; // Exit 0 so GitHub Actions does not fail the whole job on empty data.
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+static async Task WriteJsonAsync<T>(string path, T value, JsonSerializerOptions opts)
+{
+    await using var stream = File.Open(path, FileMode.Create, FileAccess.Write);
+    await JsonSerializer.SerializeAsync(stream, value, opts);
+    await stream.FlushAsync();
+}
+
+/// <summary>
+/// Walks up the directory tree starting from the binary location to find the
+/// solution root (the directory that contains src/Ulfbou.Site).  Falls back to
+/// the current working directory, which is the solution root when invoked via
+/// <c>dotnet run --project tools/SoloPulse.Collector</c>.
+/// </summary>
+static string FindOutputDir()
+{
+    var dir = new DirectoryInfo(AppContext.BaseDirectory);
+
+    while (dir is not null)
+    {
+        if (Directory.Exists(Path.Combine(dir.FullName, "src", "Ulfbou.Site")))
+            return Path.Combine(dir.FullName, "src", "Ulfbou.Site", "wwwroot", "data");
+
+        dir = dir.Parent;
+    }
+
+    return Path.Combine(Directory.GetCurrentDirectory(),
+        "src", "Ulfbou.Site", "wwwroot", "data");
+}
+
+/// <summary>Normalizes repository names for public JSON IDs and graph endpoints.</summary>
+static string NormalizeRepoId(string repoName) =>
+    repoName.Trim().ToLowerInvariant();
+
+/// <summary>Converts "dx.metadata" → "Dx.Metadata".</summary>
+static string ToDisplayName(string repoName) =>
+    string.Join('.', repoName
+        .Split('.')
+        .Select(p => p.Length > 0
+            ? char.ToUpperInvariant(p[0]) + p[1..]
+            : p));

--- a/tools/SoloPulse.Collector/README.md
+++ b/tools/SoloPulse.Collector/README.md
@@ -1,0 +1,120 @@
+# SoloPulse.Collector
+
+A .NET 10 console app that runs in GitHub Actions, queries the GitHub GraphQL API
+for a given user, calculates solo-developer metrics, and writes three static JSON
+files consumed by the Blazor WASM front-end.
+
+---
+
+## Purpose
+
+The Blazor site at `src/Ulfbou.Site` is a living logbook with no backend.
+All dynamic data comes from JSON files committed to the repo by a weekly
+GitHub Action that runs this collector.  The collector is the single source
+of truth for `repos.json`, `graph.json`, and `rhythm.json`.
+
+---
+
+## Required environment variables
+
+| Variable       | Required | Default   | Description                            |
+|----------------|----------|-----------|----------------------------------------|
+| `GITHUB_TOKEN` | **yes**  | —         | PAT or `secrets.GITHUB_TOKEN`; needs `repo:read` scope |
+| `TARGET_USER`  | no       | `ulfbou`  | GitHub login to collect data for       |
+| `OUTPUT_DIR`   | no       | auto      | Absolute path for output files; auto-detected relative to binary when omitted |
+
+---
+
+## Run locally
+
+```bash
+# From the solution root
+export GITHUB_TOKEN=ghp_your_token_here
+export TARGET_USER=ulfbou
+
+dotnet run --project tools/SoloPulse.Collector
+```
+
+Expected console output:
+
+```
+Collected 8 repos, 12 edges, 340 minutes focus, written to "…/src/Ulfbou.Site/wwwroot/data"
+```
+
+---
+
+## Run in GitHub Actions
+
+```yaml
+- name: Run SoloPulse Collector
+  run: dotnet run --project tools/SoloPulse.Collector
+  env:
+	GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+	TARGET_USER: ulfbou
+```
+
+---
+
+## Output files
+
+All files are written to `src/Ulfbou.Site/wwwroot/data/` and include
+`"schemaVersion": "1"` and `"generatedAt"` (UTC ISO 8601).
+
+### repos.json
+Per-repo solo metrics.  Key fields:
+
+| Field               | Type   | Notes |
+|---------------------|--------|-------|
+| `momentum`          | 0–100  | `commits_7d×1.0 + commits_8-14d×0.5 + commits_15-30d×0.2`, normalised |
+| `focusMinutes7d`    | int    | Commits in last 7 days clustered into sessions (gap < 90 min); sum of session durations |
+| `contextSwitchesOut`| int    | Times you left this repo for another within a 2-hour window |
+| `returnRate`        | 0–1    | Interior 24h+ gaps ÷ (interior + terminal departure); 1.0 = always returned |
+| `openLoops`         | int    | Open PRs + open issues |
+
+### graph.json
+Dependency and temporal relationship graph.  Edge types:
+
+| Type         | Meaning |
+|--------------|---------|
+| `dependency` | `.csproj` `ProjectReference` detected (top 5 repos only) |
+| `temporal`   | Commits to both repos occurred within 2 hours of each other |
+
+### rhythm.json
+Coding rhythm metrics:
+
+| Field                | Notes |
+|----------------------|-------|
+| `peakHours`          | Top 3 commit hours (UTC) across all history |
+| `avgSessionMinutes`  | Average session length in last 7 days |
+| `fragmentationIndex` | Average distinct repos per day (7-day window) |
+| `deepWorkStreakDays` | Consecutive days with at least one commit (last 30 days) |
+| `lastQuietPeriod`    | Most recent day with no commits in last 30 days |
+
+---
+
+## Package notes
+
+The task spec references `Octokit.GraphQL 8.0.0`.  That package version does not
+currently exist on NuGet; the implementation uses `HttpClient` with raw GraphQL
+POST requests, which is functionally equivalent and compatible with .NET 10 out
+of the box.  If a suitable `Octokit.GraphQL` release becomes available, the
+`GitHubClient.cs` queries can be migrated to its LINQ-based API by adding:
+
+```xml
+<PackageReference Include="Octokit.GraphQL" Version="x.y.z" />
+```
+
+---
+
+## Verify output
+
+```bash
+# Valid JSON?
+jq . src/Ulfbou.Site/wwwroot/data/repos.json
+
+# Number of repos collected
+jq '.repos | length' src/Ulfbou.Site/wwwroot/data/repos.json
+
+# Schema version present?
+jq '.schemaVersion' src/Ulfbou.Site/wwwroot/data/rhythm.json
+```

--- a/tools/SoloPulse.Collector/SoloPulse.Collector.csproj
+++ b/tools/SoloPulse.Collector/SoloPulse.Collector.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+	<OutputType>Exe</OutputType>
+	<TargetFramework>net10.0</TargetFramework>
+	<Nullable>enable</Nullable>
+	<ImplicitUsings>enable</ImplicitUsings>
+	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	<AssemblyName>SoloPulse.Collector</AssemblyName>
+	<RootNamespace>SoloPulse.Collector</RootNamespace>
+  </PropertyGroup>
+
+  <!--
+	Octokit.GraphQL is listed as the intended GraphQL SDK in the spec but the
+	implementation below uses raw HttpClient to stay compatible with .NET 10
+	without depending on a specific library version.  See README.md § "Package
+	notes" for full details.  Add it back once a .NET 10-compatible release is
+	published:
+
+	  <PackageReference Include="Octokit.GraphQL" Version="x.y.z" />
+  -->
+
+</Project>


### PR DESCRIPTION
## Summary

Implements the deterministic GitHub activity collector that generates the three public JSON contracts consumed by the Blazor site.

**What changed:**
- Added  —.NET 10 console app with no external packages (uses raw HttpClient + GraphQL to avoid Octokit.GraphQL version issues)
- Single batched GraphQL query fetches repos, last 100 commits, open PRs/issues, and root tree in one round-trip
- Calculates all solo-dev metrics: momentum (0-100 normalized), focusMinutes7d (90-min session clustering), contextSwitches, returnRate, temporal edges, dependency edges from.csproj parsing
- Writes , ,  to  with schemaVersion: 1
- Trims repos.json to top 15 repos by momentum to stay under 10KB budget (full 30 repos still in graph.json)
- Updated total 13K
-rw-r--r-- 1 Uffe 197121 1,8K maj 27 13:06 graph.json
-rw-r--r-- 1 Uffe 197121 1,2K maj 27 11:28 metrics.json
-rw-r--r-- 1 Uffe 197121 4,8K maj 27 13:06 repos.json
-rw-r--r-- 1 Uffe 197121  247 maj 27 13:06 rhythm.json
"1"
15
"1"
15
2 from placeholder to full implementation with workflow_dispatch trigger for manual runs
- Weekly job runs Sundays 23:00 UTC, commits generated JSON with [skip ci]

**Why:**
The site is a living logbook with no backend. All dynamic data must come from static files generated by CI. This establishes the collector phase and the public data contracts.

## Checklist

- [x] The site builds locally
- [x] Public copy remains visitor-first
- [x] Static data contracts still include `schemaVersion`
- [x] The homepage remains a living logbook, not a dashboard
- [x] Static docs/lab islands still work
- [x] No unrelated CI, release, Docker, or package-publishing workflows were added